### PR TITLE
104

### DIFF
--- a/src/app/private/events/page.tsx
+++ b/src/app/private/events/page.tsx
@@ -249,7 +249,7 @@ export default function EventsPage() {
           <Calendar
             selectedDate={selectedDate}
             setSelectedDate={setSelectedDate}
-            previousDisabled
+            previousDisabled={session?.user.role !== Role.ADMIN}
           />
         </div>
         <div className="flex-1 flex flex-col text-start gap-y-[32px]">


### PR DESCRIPTION
# Description

Changed one line to make previous days visible if the user is an Admin.

## Issues

Resolved #104 

## Screenshots

Admin view: 
![{70074CE6-0589-44A0-A38D-37DF6CEE04C0}](https://github.com/user-attachments/assets/08460a9c-8853-40f9-af4d-20dd82da067e)

Volunteer view:
![{768E1638-AE6D-4934-B800-45942B11BF25}](https://github.com/user-attachments/assets/94cb4ff9-a4fc-41fb-a9e9-b9634aba7f5e)


## Test

Event page on admin view

## Possible Downsides

Currently, admins and volunteers must click on every day to find events. I suggest adding an indicator for whether any event exists on a certain day (e.g., a dot above the day number).

## Additional Documentations

None
